### PR TITLE
🛟 Arrumador: Configure Workspaced, Mise tasks, and GitHub Actions

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,42 @@
+name: autorelease
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          version: 2024.12.8
+      - name: Install dependencies
+        run: mise run install
+      - name: Codegen
+        run: mise run codegen
+      - name: PR if Difference
+        uses: peter-evans/create-pull-request@v6
+        with:
+          title: "chore: update generated code"
+          commit-message: "chore: update generated code"
+          branch: "chore/update-generated-code"
+          delete-branch: true
+          base: ${{ github.ref_name }}
+      - name: CI
+        run: mise run ci
+      - name: Release
+        if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} --generate-notes

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install mise
         uses: jdx/mise-action@v2
         with:
-          version: 2024.12.8
+          version: 2025.1.0
       - name: Install dependencies
         run: mise run install
       - name: Codegen

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  mise-ci:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,8 +19,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Install mise
         uses: jdx/mise-action@v2
-        with:
-          version: 2025.1.0
       - name: Install dependencies
         run: mise run install
       - name: Codegen

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,32 @@
+[tools]
+"ubi:lucasew/workspaced" = "0.1.5"
+
+[tasks.install]
+depends = ["install:*"]
+
+[tasks."install:noop"]
+run = "true"
+hide = true
+
+[tasks.lint]
+run = "workspaced codebase lint"
+
+[tasks.fmt]
+run = "workspaced codebase format"
+
+[tasks.test]
+depends = ["test:*"]
+
+[tasks."test:noop"]
+run = "true"
+hide = true
+
+[tasks.codegen]
+depends = ["codegen:*"]
+
+[tasks."codegen:noop"]
+run = "true"
+hide = true
+
+[tasks.ci]
+depends = ["lint", "test"]


### PR DESCRIPTION
This PR configures the standard tooling for the repository using `workspaced` via `mise`.

**Changes:**
1.  **`mise.toml`**:
    -   Configures `ubi:lucasew/workspaced` (v0.1.5) as the primary tool.
    -   Defines standard tasks (`install`, `lint`, `fmt`, `test`, `codegen`, `ci`).
    -   Uses wildcard dependencies (`[task]:*`) for `install`, `test`, and `codegen` to allow for future extensibility without modifying the core task definition.
    -   Includes `noop` tasks for `install`, `test`, and `codegen` to ensure the CI pipeline runs successfully even without language-specific implementations (as the current repo state is minimal).

2.  **`.github/workflows/autorelease.yml`**:
    -   Implements a single, unified workflow for CI and releases.
    -   Follows the prescribed flow: Install -> Codegen -> PR (if diff) -> CI -> Release.
    -   Uses `gh release create` for releases.
    -   Configured to run on all pushes, tags, and manual dispatches.

**Verification:**
-   Ran `mise run ci` locally, which successfully executed the linting (via `workspaced`) and the no-op test task.
-   Verified `autorelease.yml` structure against requirements.


---
*PR created automatically by Jules for task [4938639511532529480](https://jules.google.com/task/4938639511532529480) started by @lucasew*