### PR TITLE
🧹 Janitor: Improve formatting and modernize javascript scoping

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2025-03-19: Format files and use modern block-scoping (let/const) instead of var.

--- a/index.html
+++ b/index.html
@@ -1,44 +1,46 @@
+<!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" class="top-left">
-<head>
+  <head>
     <title>Counter</title>
-    <meta charset="UTF-8">
-</head>
-<body class="top-left">
+    <meta charset="UTF-8" />
+  </head>
+  <body class="top-left">
     <style>
-        .top-left {
-            position: relative;
-            top: 0;
-            left: 0;
-        }
-        body, html {
-            height: 100%;
-            width: 100%;
-            margin: 0;
-            padding: 0;
-            position: fixed;
-            top: 0;
-            left: 0;
-        }
-        body {
-            display: table;
-        }
-        .container {
-            vertical-align: middle;
-            text-align: center;
-            display: table-cell;
-        }
+      .top-left {
+        position: relative;
+        top: 0;
+        left: 0;
+      }
+      body,
+      html {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        padding: 0;
+        position: fixed;
+        top: 0;
+        left: 0;
+      }
+      body {
+        display: table;
+      }
+      .container {
+        vertical-align: middle;
+        text-align: center;
+        display: table-cell;
+      }
     </style>
     <div class="container top-left">
-        <h1 id="counter">0</h1>
+      <h1 id="counter">0</h1>
     </div>
     <script>
-        var i = 0;
-        function incr() {
-            document.getElementById("counter").innerText = String(i);
-            i++;
-            setTimeout(incr, 1000);
-        }
-        incr()
+      let i = 0;
+      function incr() {
+        document.getElementById("counter").innerText = String(i);
+        i++;
+        setTimeout(incr, 1000);
+      }
+      incr();
     </script>
-</body>
+  </body>
 </html>

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "github>lewtec/renovate-config:base"
-  ]
+  "extends": ["config:recommended", "github>lewtec/renovate-config:base"]
 }


### PR DESCRIPTION
## What Changed
- Added missing `<!doctype html>` to `index.html`.
- Modernized variable scoping in `index.html` by changing `var i` to `let i`.
- Standardized formatting of `index.html` and `renovate.json` using Prettier.
- Added a reusable insight journal entry to `.jules/janitor.md`.

## Why This Helps
Improves code quality, consistency, and standardizes file formatting without altering application behavior. Using block-scoped variables prevents potential variable hoisting issues and improves code safety. Adding the `<!DOCTYPE html>` ensures browsers render the page correctly in standards mode.

## Before/After
- **Before**: `index.html` lacked a doctype, used `var`, and had inconsistent indentation. `renovate.json` lacked formatting.
- **After**: Files are cleanly formatted via Prettier, `index.html` is valid HTML5, and it uses modern `let` scoping.

## Verification
- Ran Prettier to verify correct formatting.
- Verified `index.html` behavior with Playwright end-to-end frontend testing, showing the counter successfully incrementing.
- Confirmed `git diff` matched expected scope.

## Assumptions
- Assumed standard HTML and JSON formatting preferences based on Prettier defaults since no project-specific Prettier config was found.
- Assumed the application requires standard `let` scoping over `var`.

## Alternatives Not Chosen
- We did not implement broader restructuring since the task was scoped purely to "quick wins" and formatting.

## How To Pivot
If the formatting defaults are not to the project's liking, create a `.prettierrc` file and rerun Prettier to conform to the new standards, then amend the commit.

## Next Knobs
- To add more linters or formatters, define `.mise.toml` or `trunk` configs.
- The `index.html` styling could be moved to a separate CSS file in a future cleanup.

---
*PR created automatically by Jules for task [12067444387586402651](https://jules.google.com/task/12067444387586402651) started by @lucasew*